### PR TITLE
fix langevin corrector alpha to general num timesteps

### DIFF
--- a/mattergen/common/diffusion/predictors_correctors.py
+++ b/mattergen/common/diffusion/predictors_correctors.py
@@ -68,9 +68,10 @@ class LatticeLangevinDiffCorrector(pc.LangevinCorrector):
         batch_idx: torch.LongTensor | None,
         score: torch.Tensor,
         t: torch.Tensor,
+        dt: torch.Tensor,
     ) -> SampleAndMean:
         assert isinstance(self.corruption, sde_lib.LatticeVPSDE)
-        alpha = self.get_alpha(t)
+        alpha = self.get_alpha(t, dt=dt)
         snr = self.snr
         noise = torch.randn_like(x)
         noise = sde_lib.make_noise_symmetric_preserve_variance(noise)

--- a/mattergen/common/gemnet/gemnet.py
+++ b/mattergen/common/gemnet/gemnet.py
@@ -381,8 +381,8 @@ class GemNetT(torch.nn.Module):
 
         value = torch.arange(idx_s.size(0), device=idx_s.device, dtype=idx_s.dtype)
         # Possibly contains multiple copies of the same edge (for periodic interactions)
-        pyg_device = get_pyg_device()
-        torch_device = get_device()
+        pyg_device = get_pyg_device() if idx_s.device != torch.device("cpu") else idx_s.device
+        torch_device = get_device() if idx_s.device != torch.device("cpu") else idx_s.device
         adj = SparseTensor(
             row=idx_t.to(pyg_device),
             col=idx_s.to(pyg_device),

--- a/mattergen/conf/data_module/mp_20.yaml
+++ b/mattergen/conf/data_module/mp_20.yaml
@@ -46,8 +46,9 @@ num_workers:
   test: 0
 
 batch_size:
-  train: 128
-  val: 128
-  test: 128
+  # total batch size of 512, adjust for number of devices, nodes, and gradient accumulation
+  train:  ${eval:'(512 // ${trainer.accumulate_grad_batches}) // (${trainer.devices} * ${trainer.num_nodes})'}
+  val: ${eval:'(64 // (${trainer.devices} * ${trainer.num_nodes})'}
+  test: ${eval:'(64 // (${trainer.devices} * ${trainer.num_nodes})'}
 
 max_epochs: 900

--- a/mattergen/diffusion/sampling/pc_sampler.py
+++ b/mattergen/diffusion/sampling/pc_sampler.py
@@ -190,7 +190,7 @@ class PredictorCorrector(Generic[Diffusable]):
                     }
                     samples_means: dict[str, Tuple[torch.Tensor, torch.Tensor]] = apply(
                         fns=fns,
-                        broadcast={"t": t},
+                        broadcast={"t": t, "dt": dt},
                         x=batch,
                         score=score,
                         batch_idx=self._multi_corruption._get_batch_indices(batch),

--- a/mattergen/diffusion/wrapped/wrapped_predictors_correctors.py
+++ b/mattergen/diffusion/wrapped/wrapped_predictors_correctors.py
@@ -56,6 +56,7 @@ class WrappedCorrectorMixin:
         batch_idx: torch.LongTensor,
         score: torch.Tensor,
         t: torch.Tensor,
+        dt: torch.Tensor,
     ) -> SampleAndMean:
         # mypy
         assert isinstance(self, pc.LangevinCorrector)
@@ -66,7 +67,7 @@ class WrappedCorrectorMixin:
             raise IncompatibleSampler(
                 f"{self.__class__.__name__} is not compatible with {self.corruption}."
             )
-        sample, mean = _super.step_given_score(x=x, score=score, t=t, batch_idx=batch_idx)
+        sample, mean = _super.step_given_score(x=x, score=score, t=t, batch_idx=batch_idx, dt=dt)
         return self.corruption.wrap(sample), self.corruption.wrap(mean)
 
 

--- a/mattergen/tests/test_diffusion_instantiation.py
+++ b/mattergen/tests/test_diffusion_instantiation.py
@@ -10,7 +10,7 @@ import hydra
 import pytest
 
 from mattergen.common.utils.globals import MODELS_PROJECT_ROOT
-from scripts.run import mattergen_main
+from mattergen.scripts.run import mattergen_main
 
 CONFIG_DIR = os.path.join(MODELS_PROJECT_ROOT, "conf")
 


### PR DESCRIPTION
Addresses issue raised in https://github.com/microsoft/mattergen/issues/79 where the $\alpha$ coefficient for the Langevin corrector was not generalizing for different numbers of integration time steps.

The way it's generalized now works as follows:

In the [score SDE paper](https://arxiv.org/abs/2011.13456), the scaling coefficient in the noise distribution $p(x_t | x_0)$ is defined as $\sqrt{\bar{\alpha}} = \exp\left(-0.5\int_0^t \beta(s) ds\right)$, so $\bar{\alpha} = \exp\left(-\int_0^t \beta(s) ds\right)$ (Eq. 29). In the discrete case $\bar{\alpha} = \prod_{t=1}^T \alpha_t$, i.e., the cumulative product of the per-step $\alpha_t$ coefficients. Thus, for the continuous case we obtain the equivalent by dividing the cumulative products for $t$ and $t + dt$, i.e.,  $\alpha_t = \frac{\bar{\alpha_t}}{\bar{\alpha}_{t + dt}}$. This happens in these lines in the code:

```python
alpha_bar = sde._marginal_mean_coeff(t) ** 2
alpha_bar_before = sde._marginal_mean_coeff(t + dt) ** 2
alpha = alpha_bar / alpha_bar_before
```
where `sde._marginal_mean_coeff(t)` corresponds to $\sqrt{\bar{\alpha}_t}$.


Also minor fixes to tests and MP20 config.