### PR TITLE
Added option to save relaxed structures in evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,9 @@ Here, we expect `energies.npy` to be a numpy array with the entries being `float
 
 If you want to save the relaxed structures, toghether with their energies, forces, and stresses, add `--structures_output_path=YOUR_PATH` to the script call, like so:
 ```bash
-mattergen-evaluate --structures_path=$RESULTS_PATH --energies_path='energies.npy' --relax=False --structure_matcher='disordered' --save_as='metrics' --structures_output_path="relaxed_structures.extxyz"
+mattergen-evaluate --structures_path=$RESULTS_PATH --relax=True --structure_matcher='disordered' --save_as='metrics' --structures_output_path="relaxed_structures.extxyz"
 ```
+
 ### Evaluate using your own reference dataset
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ This script will try to read structures from disk in the following precedence or
 
 Here, we expect `energies.npy` to be a numpy array with the entries being `float` energies in the same order as the structures read from `$RESULTS_PATH`.
 
+If you want to save the relaxed structures, toghether with their energies, forces, and stresses, add `--structures_output_path=YOUR_PATH` to the script call, like so:
+```bash
+mattergen-evaluate --structures_path=$RESULTS_PATH --energies_path='energies.npy' --relax=False --structure_matcher='disordered' --save_as='metrics' --structures_output_path="relaxed_structures.extxyz"
+```
 ### Evaluate using your own reference dataset
 
 > [!IMPORTANT]

--- a/mattergen/evaluation/evaluate.py
+++ b/mattergen/evaluation/evaluate.py
@@ -25,6 +25,7 @@ def evaluate(
     save_as: str | None = None,
     potential_load_path: str | None = None,
     device: str = str(get_device()),
+    structures_output_path: str | None = None,
 ) -> dict[str, float | int]:
     """Evaluate the structures against a reference dataset.
 
@@ -37,6 +38,7 @@ def evaluate(
         save_as: Save the metrics as a JSON file.
         potential_load_path: Path to the Machine Learning potential to use for relaxation.
         device: Device to use for relaxation.
+        structures_output_path: Path to save the relaxed structures.
 
     Returns:
         metrics: a dictionary of metrics and their values.
@@ -45,7 +47,7 @@ def evaluate(
         raise ValueError("Cannot accept energies if relax is True.")
     if relax:
         relaxed_structures, energies = relax_structures(
-            structures, device=device, load_path=potential_load_path
+            structures, device=device, potential_load_path=potential_load_path, output_path=structures_output_path
         )
     else:
         relaxed_structures = structures

--- a/mattergen/evaluation/utils/relaxation.py
+++ b/mattergen/evaluation/utils/relaxation.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 from ase import Atoms
+from ase.io import write
 from mattersim.applications.batch_relax import BatchRelaxer
 from mattersim.forcefield.potential import Potential
 from mattersim.utils.logger_utils import get_logger
@@ -16,27 +17,31 @@ logger.level("ERROR")
 
 
 def relax_atoms(
-    atoms: list[Atoms], device: str = str(get_device()), load_path: str = None, **kwargs
+    atoms: list[Atoms], device: str = str(get_device()), potential_load_path: str = None, output_path: str | None = None, **kwargs
 ) -> tuple[list[Atoms], np.ndarray]:
     potential = Potential.from_checkpoint(
-        device=device, load_path=load_path, load_training_state=False
+        device=device, load_path=potential_load_path, load_training_state=False
     )
     batch_relaxer = BatchRelaxer(potential=potential, filter="EXPCELLFILTER", **kwargs)
     relaxation_trajectories = batch_relaxer.relax(atoms)
     relaxed_atoms = [t[-1] for t in relaxation_trajectories.values()]
     total_energies = np.array([a.info["total_energy"] for a in relaxed_atoms])
+    if output_path:
+        write(output_path, relaxed_atoms, format="extxyz")
+        logger.info(f"Relaxed structures saved to {output_path}")
     return relaxed_atoms, total_energies
 
 
 def relax_structures(
     structures: Structure | list[Structure],
     device: str = str(get_device()),
-    load_path: str = None,
+    potential_load_path: str = None,
+    output_path : str | None = None,
     **kwargs
 ) -> tuple[list[Structure], np.ndarray]:
     if isinstance(structures, Structure):
         structures = [structures]
     atoms = [AseAtomsAdaptor.get_atoms(s) for s in structures]
-    relaxed_atoms, total_energies = relax_atoms(atoms, device=device, load_path=load_path, **kwargs)
+    relaxed_atoms, total_energies = relax_atoms(atoms, device=device, potential_load_path=potential_load_path, output_path=output_path, **kwargs)
     relaxed_structures = [AseAtomsAdaptor.get_structure(a) for a in relaxed_atoms]
     return relaxed_structures, total_energies

--- a/mattergen/scripts/evaluate.py
+++ b/mattergen/scripts/evaluate.py
@@ -29,6 +29,7 @@ def main(
     ) = None,
     reference_dataset_path: str | None = None,
     device: str = str(get_device()),
+    structures_output_path: str | None = None,
 ):
     structures = load_structures(Path(structures_path))
     energies = np.load(energies_path) if energies_path else None
@@ -50,6 +51,7 @@ def main(
         potential_load_path=potential_load_path,
         reference=reference,
         device=device,
+        structures_output_path=structures_output_path,
     )
     print(json.dumps(metrics, indent=2))
 


### PR DESCRIPTION
This PR:

1. Adds the argument `output_path` to `relax_atoms` and all the functions calling it. The argument is None by default. If a string is provided, the relaxed structures will be saved along with their energy, forces, and stresses.
2. Renames `load_path` to `potential_load_path` in `relax_atoms` and other functions to improve clarity

Closes #101