### PR TITLE
Modernize logger interface

### DIFF
--- a/mattergen/diffusion/corruption/corruption.py
+++ b/mattergen/diffusion/corruption/corruption.py
@@ -49,7 +49,7 @@ def maybe_expand(x: torch.Tensor, batch: B, like: torch.Tensor = None) -> torch.
         return x
     else:
         if x.shape[0] == batch.shape[0]:
-            logging.warn(
+            logging.warning(
                 "Warning: batch shape is == x shape, are you trying to expand something that is already expanded?"
             )
         return x[batch]


### PR DESCRIPTION
## PR Summary
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
This small PR resolve it.