### PR TITLE
Fix numpy 2.x compatibility: replace np.math.factorial with math.factorial

### DIFF
--- a/mattergen/common/gemnet/layers/basis_utils.py
+++ b/mattergen/common/gemnet/layers/basis_utils.py
@@ -5,6 +5,7 @@ Licensed under the MIT License.
 Adapted from https://github.com/FAIR-Chem/fairchem/blob/main/src/fairchem/core/models/gemnet/layers/basis_utils.py.
 """
 
+import math
 from typing import Any, List
 
 import numpy as np
@@ -106,8 +107,8 @@ def sph_harm_prefactor(l_degree: int, m_order: int) -> float:
     return (
         (2 * l_degree + 1)
         / (4 * np.pi)
-        * np.math.factorial(l_degree - abs(m_order))
-        / np.math.factorial(l_degree + abs(m_order))
+        * math.factorial(l_degree - abs(m_order))
+        / math.factorial(l_degree + abs(m_order))
     ) ** 0.5
 
 
@@ -177,8 +178,8 @@ def associated_legendre_polynomials(
                     for m_order in range(1, l_degree + 1):  # P_1(-1), P_2(-1) P_2(-2)
                         P_l_m[l_degree][-m_order] = sym.simplify(
                             (-1) ** m_order
-                            * np.math.factorial(l_degree - m_order)
-                            / np.math.factorial(l_degree + m_order)
+                            * math.factorial(l_degree - m_order)
+                            / math.factorial(l_degree + m_order)
                             * P_l_m[l_degree][m_order]
                         )
 


### PR DESCRIPTION
## Summary

`numpy.math` was deprecated in numpy 1.25 and removed in numpy 2.0 ([release notes](https://numpy.org/doc/stable/release/2.0.0-notes.html#expired-deprecations)).

This causes `AttributeError: module 'numpy' has no attribute 'math'` when using any checkpoint that triggers `GemNetTCtrl` with `condition_on_adapt` — specifically in `basis_utils.py:sph_harm_prefactor()` and `associated_legendre_polynomials()`.

## Fix

Replace `np.math.factorial` with `math.factorial` from the standard library (identical behavior, zero additional dependencies). 4 occurrences in 1 file.

## Affected checkpoints

**Broken** (with numpy >= 2.0): `space_group`, `dft_band_gap`, `dft_mag_density`, `ml_bulk_modulus`, `dft_mag_density_hhi_score`

**Unaffected** (don't trigger the code path): `chemical_system`, `chemical_system_energy_above_hull`

## Reproduction

```python
from mattergen.generator import CrystalGenerator
from mattergen.common.utils.data_classes import MatterGenCheckpointInfo

info = MatterGenCheckpointInfo.from_hf_hub("space_group")
gen = CrystalGenerator(checkpoint_info=info, batch_size=1, num_batches=1,
                        properties_to_condition_on={"space_group": 225})
gen.generate()  # → AttributeError: module 'numpy' has no attribute 'math'
```

## Verified

Generated 192 structures with `space_group` checkpoint after applying this fix (RTX 4070, numpy 2.1.3, PyTorch 2.4.1).

🤖 Generated with [Claude Code](https://claude.ai/code)