### PR TITLE
fix: use lmdb_get to access already loaded data without re-reading

### DIFF
--- a/mattergen/evaluation/reference/reference_dataset_serializer.py
+++ b/mattergen/evaluation/reference/reference_dataset_serializer.py
@@ -136,7 +136,7 @@ class LMDBBackedReferenceDatasetImpl(ReferenceDatasetImpl):
         """
         self.env = lmdb_open(lmdb_path, readonly=True)
         self.num_entries_by_chemsys_reduced_formulas = (
-            self._build_num_entries_by_chemsys_reduced_formulas(lmdb_path)
+            self._build_num_entries_by_chemsys_reduced_formulas()
         )
         self.total_num_entries = sum(
             sum(d.values()) for d in self.num_entries_by_chemsys_reduced_formulas.values()
@@ -144,14 +144,12 @@ class LMDBBackedReferenceDatasetImpl(ReferenceDatasetImpl):
         # close the LMDB environment when this object is garbage collected
         weakref.finalize(self, self._cleanup, self.env, cleanup_dir)
 
-    def _build_num_entries_by_chemsys_reduced_formulas(
-        self, lmdb_path: Path
-    ) -> dict[str, dict[str, int]]:
-        chemical_systems = lmdb_read_metadata(lmdb_path, "chemical_systems")
+    def _build_num_entries_by_chemsys_reduced_formulas(self) -> dict[str, dict[str, int]]:        
         result: defaultdict[str, dict[str, int]] = defaultdict(dict)
         with self.env.begin() as txn:
+            chemical_systems = lmdb_get(txn, "chemical_systems")
             for chemsys in chemical_systems:
-                reduced_formulas = lmdb_read_metadata(lmdb_path, f"{chemsys}.reduced_formulas")
+                reduced_formulas = lmdb_get(txn, f"{chemsys}.reduced_formulas")
                 for reduced_formula in reduced_formulas:
                     result[chemsys][reduced_formula] = lmdb_get(
                         txn, f"{chemsys}.{reduced_formula}.length"

--- a/mattergen/tests/test_reference_dataset_serializer.py
+++ b/mattergen/tests/test_reference_dataset_serializer.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from pymatgen.core import Lattice, Structure
+from pymatgen.entries.computed_entries import ComputedStructureEntry
+
+from mattergen.evaluation.reference.reference_dataset import ReferenceDataset
+from mattergen.evaluation.reference.reference_dataset_serializer import LMDBGZSerializer
+
+
+def test_deserialize_does_not_reopen_same_lmdb_while_environment_is_active(
+    tmp_path: Path,
+) -> None:
+    serializer = LMDBGZSerializer()
+    dataset_path = tmp_path / "reference.lmdb.gz"
+    entry = ComputedStructureEntry(
+        structure=Structure(
+            lattice=Lattice.cubic(3.5),
+            species=["Fe", "O"],
+            coords=[[0, 0, 0], [0.5, 0.5, 0.5]],
+        ),
+        energy=0.0,
+    )
+    serializer.serialize(
+        ReferenceDataset.from_entries("reference", [entry]),
+        dataset_path,
+    )
+
+    reference = serializer.deserialize(dataset_path)
+    assert reference.name == "reference"
+    assert reference.impl.chemical_systems == ("Fe-O",)
+    assert len(reference) == 1
+    reference.impl.cleanup(cleanup_dir=True)


### PR DESCRIPTION
This small PR is a fix for the following kind of error:
```bash
File "~/mattergen/.venv/bin/mattergen-evaluate", line 10, in <module>
    sys.exit(_main())
File "~/mattergen/mattergen/scripts/evaluate.py", line 60, in _main
    fire.Fire(main)
File "~/mattergen/.venv/lib/python3.10/site-packages/fire/core.py", line 135, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
File "~/mattergen/.venv/lib/python3.10/site-packages/fire/core.py", line 468, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
File "~/mattergen/.venv/lib/python3.10/site-packages/fire/core.py", line 684, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
File "~/mattergen/mattergen/scripts/evaluate.py", line 43, in main
    reference = LMDBGZSerializer().deserialize(reference_dataset_path)
File "~/mattergen/mattergen/evaluation/reference/reference_dataset_serializer.py", line 107, in deserialize
    impl=LMDBBackedReferenceDatasetImpl(lmdb_path, cleanup_dir=True),
File "~/mattergen/mattergen/evaluation/reference/reference_dataset_serializer.py", line 139, in __init__
    self._build_num_entries_by_chemsys_reduced_formulas(lmdb_path)
File "~/mattergen/mattergen/evaluation/reference/reference_dataset_serializer.py", line 150, in _build_num_entries_by_chemsys_reduced_formulas
    chemical_systems = lmdb_read_metadata(lmdb_path, "chemical_systems")
File "~/mattergen/mattergen/evaluation/utils/lmdb_utils.py", line 41, in lmdb_read_metadata
    with lmdb_open(db_path, readonly=True) as db:
File "~/mattergen/mattergen/evaluation/utils/lmdb_utils.py", line 21, in lmdb_open
    return lmdb.open(
lmdb.Error: The environment '****' is already open in this process.
```

which started occurring following the release of this change to LMDB: https://github.com/jnwatson/py-lmdb/commit/2b26c9f0ece873874c6d7a1c4a2fa91590dfac2e, making opening the same environment more than once an error. 

An alternative fix to this issue would be to pin the lmdb version used by mattergen to be <2.0.0, but then we remain vulnerable to the kinds of issues the change to lmdb aims to avoid (e.g. potential segfaults).

As far as I understand, Mattergen evaluation may be blocked in many environments currently, due to installation potentially picking up the latest lmdb version.