### PR TITLE
Fix Linux PyPI installation dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ source .venv/bin/activate
 uv pip install -e .
 ```
 
+Alternatively, install the released package from PyPI with the matching pre-built PyTorch Geometric CUDA wheels:
+```bash
+uv pip install mattergen --find-links https://data.pyg.org/whl/torch-2.2.0+cu121.html
+```
+
 Note that our datasets and model checkpoints are provided inside this repo via [Git Large File Storage (LFS)](https://git-lfs.com/).
 To find out whether LFS is installed on your machine, run
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,9 +68,9 @@ dependencies = [
 "setuptools<81",
 "SMACT",
 "sympy>=1.11.1",
-"torch==2.2.1+cu118; sys_platform == 'linux'", 
-"torchvision==0.17.1+cu118; sys_platform == 'linux'",
-"torchaudio==2.2.1+cu118; sys_platform == 'linux'",
+"torch==2.2.1; sys_platform == 'linux'",
+"torchvision==0.17.1; sys_platform == 'linux'",
+"torchaudio==2.2.1; sys_platform == 'linux'",
 "torch==2.4.1; sys_platform == 'darwin'",
 "torchvision==0.19.1; sys_platform == 'darwin'",
 "torchaudio==2.4.1; sys_platform == 'darwin'",
@@ -101,27 +101,27 @@ torch = { index = "pytorch_linux",  marker = "sys_platform == 'linux'" }
 torchvision = { index = "pytorch_linux",  marker = "sys_platform == 'linux'" }
 torchaudio = { index = "pytorch_linux",  marker = "sys_platform == 'linux'" }
 pyg-lib = [
-  { url = "https://data.pyg.org/whl/torch-2.2.0%2Bcu118/pyg_lib-0.4.0%2Bpt22cu118-cp310-cp310-linux_x86_64.whl",  marker = "sys_platform == 'linux'" },
+  { url = "https://data.pyg.org/whl/torch-2.2.0%2Bcu121/pyg_lib-0.4.0%2Bpt22cu121-cp310-cp310-linux_x86_64.whl",  marker = "sys_platform == 'linux'" },
   { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcpu/pyg_lib-0.4.0%2Bpt24-cp310-cp310-macosx_14_0_universal2.whl",  marker = "sys_platform == 'darwin'" }
 ]
 torch_cluster = [
-  { url = "https://data.pyg.org/whl/torch-2.2.0%2Bcu118/torch_cluster-1.6.3%2Bpt22cu118-cp310-cp310-linux_x86_64.whl",  marker = "sys_platform == 'linux'" },
+  { url = "https://data.pyg.org/whl/torch-2.2.0%2Bcu121/torch_cluster-1.6.3%2Bpt22cu121-cp310-cp310-linux_x86_64.whl",  marker = "sys_platform == 'linux'" },
   { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcpu/torch_cluster-1.6.3-cp310-cp310-macosx_10_9_universal2.whl",  marker = "sys_platform == 'darwin'"  }
 ]
 
 torch_scatter = [
-  { url = "https://data.pyg.org/whl/torch-2.2.0%2Bcu118/torch_scatter-2.1.2%2Bpt22cu118-cp310-cp310-linux_x86_64.whl",  marker = "sys_platform == 'linux'" },
+  { url = "https://data.pyg.org/whl/torch-2.2.0%2Bcu121/torch_scatter-2.1.2%2Bpt22cu121-cp310-cp310-linux_x86_64.whl",  marker = "sys_platform == 'linux'" },
   { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcpu/torch_scatter-2.1.2-cp310-cp310-macosx_10_9_universal2.whl",  marker = "sys_platform == 'darwin'"  }
 ]
 
 torch_sparse = [
-  { url = "https://data.pyg.org/whl/torch-2.2.0%2Bcu118/torch_sparse-0.6.18%2Bpt22cu118-cp310-cp310-linux_x86_64.whl",  marker = "sys_platform == 'linux'" },
+  { url = "https://data.pyg.org/whl/torch-2.2.0%2Bcu121/torch_sparse-0.6.18%2Bpt22cu121-cp310-cp310-linux_x86_64.whl",  marker = "sys_platform == 'linux'" },
   { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcpu/torch_sparse-0.6.18-cp310-cp310-macosx_11_0_universal2.whl",  marker = "sys_platform == 'darwin'"  }
 ]
 
 [[tool.uv.index]]
 name = "pytorch_linux"
-url = "https://download.pytorch.org/whl/cu118"
+url = "https://download.pytorch.org/whl/cu121"
 explicit = true
 
 


### PR DESCRIPTION
## Summary
- use PyPI-compatible PyTorch 2.2.1 dependency pins on Linux
- align repository-managed PyTorch and PyG wheels on CUDA 12.1
- document the PyG wheel source needed for direct PyPI installation
- preserve the existing one-command source installation workflow

## Validation
- resolved the built MatterGen wheel in a clean Python 3.10 environment
- confirmed matching CUDA 12.1 wheels for torch, torchvision, torchaudio, torch-cluster, torch-scatter, and torch-sparse

Fixes #246