### PR TITLE
Fix TRI reference energy corrections

### DIFF
--- a/data-release/alex-mp/reference_TRI2024correction.gz
+++ b/data-release/alex-mp/reference_TRI2024correction.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3631b54625f2a5410fb83aab16fda78073a2a713e8457e3beec523d0682315f5
-size 901725196
+oid sha256:ab1b4426901ff7b0f8af6ee9c3cc0dd2fbe4b65c758ef2a95683071492d1c51d
+size 906892717

--- a/mattergen/evaluation/reference/correction_schemes.py
+++ b/mattergen/evaluation/reference/correction_schemes.py
@@ -80,7 +80,10 @@ class TRI110Compatibility2024(Compatibility):
             # energy adjustments are applied additively in downstram pymatgen code, so
             # refactor multiplicate factor as an addition to uncorrected energy
             adjustments.append(
-                EnergyAdjustment(value=entry.energy * (self.PBE_CORRECTION - 1.0), name="TRI110PBE")
+                EnergyAdjustment(
+                    value=entry.uncorrected_energy * (self.PBE_CORRECTION - 1.0),
+                    name="TRI110PBE",
+                )
             )
 
         if entry.parameters.get("run_type") == "GGA+U":

--- a/mattergen/tests/test_correction_schemes.py
+++ b/mattergen/tests/test_correction_schemes.py
@@ -1,0 +1,39 @@
+import pytest
+from pymatgen.core import Element
+from pymatgen.entries.computed_entries import ComputedEntry, EnergyAdjustment
+
+from mattergen.evaluation.reference.correction_schemes import TRI110Compatibility2024
+
+
+def test_tri_pbe_correction_uses_uncorrected_energy() -> None:
+    entry = ComputedEntry(
+        composition="NaCl",
+        energy=-6.77796,
+        parameters={"run_type": "GGA"},
+    )
+    entry.energy_adjustments.append(
+        EnergyAdjustment(value=-0.614, name="MP2020 anion correction (Cl)")
+    )
+
+    adjustments = TRI110Compatibility2024().get_adjustments(entry)
+
+    assert len(adjustments) == 1
+    assert adjustments[0].name == "TRI110PBE"
+    assert adjustments[0].value == pytest.approx(0.108 * entry.uncorrected_energy)
+
+
+def test_tri_u_correction_is_separate_from_pbe_scaling() -> None:
+    entry = ComputedEntry(
+        composition="FeO",
+        energy=-10.0,
+        parameters={"run_type": "GGA+U"},
+    )
+
+    adjustments = TRI110Compatibility2024().get_adjustments(entry)
+
+    assert {adjustment.name: adjustment.value for adjustment in adjustments} == pytest.approx(
+        {
+            "TRI110PBE": -1.08,
+            "TRI110PBE_U": TRI110Compatibility2024.U_CORRECTION[Element("Fe")],
+        }
+    )


### PR DESCRIPTION
## Summary
- compute the TRI110 PBE adjustment from uncorrected energy so existing adjustments cannot be compounded
- regenerate all 845,997 entries in the bundled TRI reference dataset
- add regression coverage for pre-corrected entries and separate GGA+U adjustments

## Validation
- confirmed every regenerated entry uses `0.108 * uncorrected_energy` for `TRI110PBE`
- confirmed NaCl (`mp-22862`) now has a `-0.73202 eV` adjustment instead of `-0.79833 eV`

Fixes #251